### PR TITLE
Changed SignatureWriter to not access the signature stream through BinaryWriter.BaseStream property

### DIFF
--- a/source/FastRsync/Signature/ISignatureWriter.cs
+++ b/source/FastRsync/Signature/ISignatureWriter.cs
@@ -18,10 +18,12 @@ namespace FastRsync.Signature
 
     public class SignatureWriter : ISignatureWriter
     {
+        private readonly Stream _signatureStream;
         private readonly BinaryWriter signaturebw;
 
         public SignatureWriter(Stream signatureStream)
         {
+            this._signatureStream = signatureStream;
             this.signaturebw = new BinaryWriter(signatureStream);
         }
 
@@ -44,7 +46,7 @@ namespace FastRsync.Signature
             var msbw = new BinaryWriter(ms);
             WriteMetadataInternal(msbw, metadata);
             ms.Seek(0, SeekOrigin.Begin);
-            await ms.CopyToAsync(signaturebw.BaseStream).ConfigureAwait(false);
+            await ms.CopyToAsync(_signatureStream).ConfigureAwait(false);
         }
 
         public void WriteChunk(ChunkSignature signature)
@@ -58,7 +60,7 @@ namespace FastRsync.Signature
         {
             signaturebw.Write(signature.Length);
             signaturebw.Write(signature.RollingChecksum);
-            await signaturebw.BaseStream.WriteAsync(signature.Hash, 0, signature.Hash.Length).ConfigureAwait(false);
+            await _signatureStream.WriteAsync(signature.Hash, 0, signature.Hash.Length).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
This turned out to be a significant scalability bottleneck when writing signatures directly to blob storage.

The `BinaryWriter.BaseStream` property read accessor performs a synchronous (blocking) flush of the stream:

https://github.com/dotnet/corefx/blob/d21453e1cfa2e2546deccbd3a4be46341e4ba5d1/src/Common/src/CoreLib/System/IO/BinaryWriter.cs#L90-L100

If the stream is a `BlobWriteStream` then this involves waiting on one or more network calls to blob storage. Since this is done completely synchronously, and with every chunk that the `SignatureWriter` writes, this blocks the calling thread for the duration of the flush operation, which in turn leads to thread pool starvation under heavy load.

The solution is to not use the `BinaryWriter.BaseStream` property from `SignatureWriter` but instead save a reference to the underlying stream and use that.