### PR TITLE
Change MD5 Usage to XXHash3

### DIFF
--- a/source/FastRsync/Delta/DeltaBuilder.cs
+++ b/source/FastRsync/Delta/DeltaBuilder.cs
@@ -23,19 +23,18 @@ namespace FastRsync.Delta
 
         public void BuildDelta(Stream newFileStream, ISignatureReader signatureReader, IDeltaWriter deltaWriter)
         {
-            var newFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
-            newFileStream.Seek(0, SeekOrigin.Begin);
-            var newFileHash = newFileVerificationHashAlgorithm.ComputeHash(newFileStream);
-            newFileStream.Seek(0, SeekOrigin.Begin);
-
             var signature = signatureReader.ReadSignature();
             var chunks = OrderChunksByChecksum(signature.Chunks);
             var chunkMap = CreateChunkMap(chunks, out int maxChunkSize, out int minChunkSize);
 
+            newFileStream.Seek(0, SeekOrigin.Begin);
+            var newFileHash = signature.HashAlgorithm.ComputeHash(newFileStream);
+            newFileStream.Seek(0, SeekOrigin.Begin);
+
             deltaWriter.WriteMetadata(new DeltaMetadata
             {
                 HashAlgorithm = signature.HashAlgorithm.Name,
-                ExpectedFileHashAlgorithm = newFileVerificationHashAlgorithm.Name,
+                ExpectedFileHashAlgorithm = signature.HashAlgorithm.Name,
                 ExpectedFileHash = Convert.ToBase64String(newFileHash),
                 BaseFileHash = signature.Metadata.BaseFileHash,
                 BaseFileHashAlgorithm = signature.Metadata.BaseFileHashAlgorithm
@@ -141,19 +140,18 @@ namespace FastRsync.Delta
 
         public async Task BuildDeltaAsync(Stream newFileStream, ISignatureReader signatureReader, IDeltaWriter deltaWriter)
         {
-            var newFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
-            newFileStream.Seek(0, SeekOrigin.Begin);
-            var newFileHash = await newFileVerificationHashAlgorithm.ComputeHashAsync(newFileStream).ConfigureAwait(false);
-            newFileStream.Seek(0, SeekOrigin.Begin);
-
             var signature = signatureReader.ReadSignature();
             var chunks = OrderChunksByChecksum(signature.Chunks);
             var chunkMap = CreateChunkMap(chunks, out int maxChunkSize, out int minChunkSize);
 
+            newFileStream.Seek(0, SeekOrigin.Begin);
+            var newFileHash = await signature.HashAlgorithm.ComputeHashAsync(newFileStream).ConfigureAwait(false);
+            newFileStream.Seek(0, SeekOrigin.Begin);
+
             deltaWriter.WriteMetadata(new DeltaMetadata
             {
                 HashAlgorithm = signature.HashAlgorithm.Name,
-                ExpectedFileHashAlgorithm = newFileVerificationHashAlgorithm.Name,
+                ExpectedFileHashAlgorithm = signature.HashAlgorithm.Name,
                 ExpectedFileHash = Convert.ToBase64String(newFileHash),
                 BaseFileHash = signature.Metadata.BaseFileHash,
                 BaseFileHashAlgorithm = signature.Metadata.BaseFileHashAlgorithm

--- a/source/FastRsync/Delta/DeltaBuilder.cs
+++ b/source/FastRsync/Delta/DeltaBuilder.cs
@@ -23,7 +23,7 @@ namespace FastRsync.Delta
 
         public void BuildDelta(Stream newFileStream, ISignatureReader signatureReader, IDeltaWriter deltaWriter)
         {
-            var newFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.Md5();
+            var newFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
             newFileStream.Seek(0, SeekOrigin.Begin);
             var newFileHash = newFileVerificationHashAlgorithm.ComputeHash(newFileStream);
             newFileStream.Seek(0, SeekOrigin.Begin);

--- a/source/FastRsync/Delta/DeltaBuilder.cs
+++ b/source/FastRsync/Delta/DeltaBuilder.cs
@@ -141,7 +141,7 @@ namespace FastRsync.Delta
 
         public async Task BuildDeltaAsync(Stream newFileStream, ISignatureReader signatureReader, IDeltaWriter deltaWriter)
         {
-            var newFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.Md5();
+            var newFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
             newFileStream.Seek(0, SeekOrigin.Begin);
             var newFileHash = await newFileVerificationHashAlgorithm.ComputeHashAsync(newFileStream).ConfigureAwait(false);
             newFileStream.Seek(0, SeekOrigin.Begin);

--- a/source/FastRsync/Signature/SignatureBuilder.cs
+++ b/source/FastRsync/Signature/SignatureBuilder.cs
@@ -97,7 +97,7 @@ namespace FastRsync.Signature
             });
 
             baseFileStream.Seek(0, SeekOrigin.Begin);
-            var baseFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.Md5();
+            var baseFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
             var baseFileHash = await baseFileVerificationHashAlgorithm.ComputeHashAsync(baseFileStream).ConfigureAwait(false);
 
             await signatureWriter.WriteMetadataAsync(new SignatureMetadata

--- a/source/FastRsync/Signature/SignatureBuilder.cs
+++ b/source/FastRsync/Signature/SignatureBuilder.cs
@@ -68,7 +68,7 @@ namespace FastRsync.Signature
             });
 
             baseFileStream.Seek(0, SeekOrigin.Begin);
-            var baseFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.Md5();
+            var baseFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
             var baseFileHash = baseFileVerificationHashAlgorithm.ComputeHash(baseFileStream);
 
             signatureWriter.WriteMetadata(new SignatureMetadata

--- a/source/FastRsync/Signature/SignatureBuilder.cs
+++ b/source/FastRsync/Signature/SignatureBuilder.cs
@@ -68,14 +68,13 @@ namespace FastRsync.Signature
             });
 
             baseFileStream.Seek(0, SeekOrigin.Begin);
-            var baseFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
-            var baseFileHash = baseFileVerificationHashAlgorithm.ComputeHash(baseFileStream);
+            var baseFileHash = HashAlgorithm.ComputeHash(baseFileStream);
 
             signatureWriter.WriteMetadata(new SignatureMetadata
             {
                 ChunkHashAlgorithm = HashAlgorithm.Name,
                 RollingChecksumAlgorithm = RollingChecksumAlgorithm.Name,
-                BaseFileHashAlgorithm = baseFileVerificationHashAlgorithm.Name,
+                BaseFileHashAlgorithm = HashAlgorithm.Name,
                 BaseFileHash = Convert.ToBase64String(baseFileHash)
             });
 
@@ -97,14 +96,13 @@ namespace FastRsync.Signature
             });
 
             baseFileStream.Seek(0, SeekOrigin.Begin);
-            var baseFileVerificationHashAlgorithm = SupportedAlgorithms.Hashing.XxHash3();
-            var baseFileHash = await baseFileVerificationHashAlgorithm.ComputeHashAsync(baseFileStream).ConfigureAwait(false);
+            var baseFileHash = await HashAlgorithm.ComputeHashAsync(baseFileStream).ConfigureAwait(false);
 
             await signatureWriter.WriteMetadataAsync(new SignatureMetadata
             {
                 ChunkHashAlgorithm = HashAlgorithm.Name,
                 RollingChecksumAlgorithm = RollingChecksumAlgorithm.Name,
-                BaseFileHashAlgorithm = baseFileVerificationHashAlgorithm.Name,
+                BaseFileHashAlgorithm = HashAlgorithm.Name,
                 BaseFileHash = Convert.ToBase64String(baseFileHash)
             }).ConfigureAwait(false);
 


### PR DESCRIPTION
~~XXHash3 makes similar quality hashes compared to MD5 but is in almost every situation faster over MD5. It seems logical to choose XXHash3 over MD5 for this operation~~

After looking further into this I believe XXHash3 is a 64 bit only hashing algorithm. As a compromise I changed this to hash the file with the hashing algo chosen by the user for the other operations so that this would work on 32 bit systems given a 32 bit compatible algo was chosen