### PR TITLE
Add Adler32RollingChecksumV3.

### DIFF
--- a/source/FastRsync.Benchmarks/RollingChecksumBenchmark.cs
+++ b/source/FastRsync.Benchmarks/RollingChecksumBenchmark.cs
@@ -1,27 +1,33 @@
 ﻿using System;
-using System.IO;
 using BenchmarkDotNet.Attributes;
 using FastRsync.Core;
 using FastRsync.Hash;
-using FastRsync.Signature;
 
 namespace FastRsync.Benchmarks
 {
     public class RollingCheckSumBenchmark
     {
-        [Params(128, 16974, 356879)]
+        [Params(128, 16974, 356879)] 
         public int N { get; set; }
 
         private byte[] data;
 
         private readonly IRollingChecksum adler32RollingAlgorithm = SupportedAlgorithms.Checksum.Adler32Rolling();
         private readonly IRollingChecksum adler32RollingV2Algorithm = SupportedAlgorithms.Checksum.Adler32RollingV2();
+        private readonly IRollingChecksum adler32RollingV3Algorithm = SupportedAlgorithms.Checksum.Adler32RollingV3();
+
+        private uint checksum32;
+        private uint checksum32V2;
+        private uint checksum32V3;
 
         [GlobalSetup]
         public void GlobalSetup()
         {
             data = new byte[N];
             new Random().NextBytes(data);
+            checksum32 = adler32RollingAlgorithm.Calculate(data, 0, data.Length - 1);
+            checksum32V2 = adler32RollingV2Algorithm.Calculate(data, 0, data.Length - 1);
+            checksum32V3 = adler32RollingV3Algorithm.Calculate(data, 0, data.Length - 1);
         }
 
         [Benchmark]
@@ -34,6 +40,30 @@ namespace FastRsync.Benchmarks
         public uint Adler32RollingV2CalculateChecksum()
         {
             return adler32RollingV2Algorithm.Calculate(data, 0, data.Length);
+        }
+
+        [Benchmark]
+        public uint Adler32RollingV3CalculateChecksum()
+        {
+            return adler32RollingV3Algorithm.Calculate(data, 0, data.Length);
+        }
+
+        [Benchmark]
+        public uint Adler32RollingRotateChecksum()
+        {
+            return adler32RollingAlgorithm.Rotate(checksum32, data[0], data[^1], data.Length - 1);
+        }
+
+        [Benchmark]
+        public uint Adler32RollingV2RotateChecksum()
+        {
+            return adler32RollingV2Algorithm.Rotate(checksum32V2, data[0], data[^1], data.Length - 1);
+        }
+
+        [Benchmark]
+        public uint Adler32RollingV3RotateChecksum()
+        {
+            return adler32RollingV3Algorithm.Rotate(checksum32V3, data[0], data[^1], data.Length - 1);
         }
     }
 }

--- a/source/FastRsync.Tests/Adler32RollingChecksumAlgorithmsTests.cs
+++ b/source/FastRsync.Tests/Adler32RollingChecksumAlgorithmsTests.cs
@@ -1,0 +1,125 @@
+﻿using FastRsync.Hash;
+using NSubstitute;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FastRsync.Core;
+using FastRsync.Delta;
+using FastRsync.Diagnostics;
+
+namespace FastRsync.Tests;
+
+[TestFixture]
+public class Adler32RollingChecksumAlgorithmsTests
+{
+    public static IRollingChecksum[] RollingChecksumAlgorithms =>
+        typeof(IRollingChecksum).Assembly.GetTypes()
+            .Where(t => typeof(IRollingChecksum).IsAssignableFrom(t)
+                        && t is {IsClass: true, IsAbstract:false}
+                        && t.GetConstructor(Type.EmptyTypes) != null
+                        && t.GetCustomAttribute<ObsoleteAttribute>() == null)
+            .Select(t => (IRollingChecksum)Activator.CreateInstance(t))
+            .ToArray();
+
+    private static readonly int[] Sizes = [1024 * 1024 / 2, 10 * 1024 * 1024, 20 * 1024 * 1024];
+    private static readonly int[] ModificationPercentages = [1, 3, 5, 10];
+
+    [Test]
+    [TestCaseSource(nameof(RollingChecksumAlgorithms))]
+    public void EveryRollingChecksumAlgorithmCalculatesRotateCorrectly(IRollingChecksum rollingChecksumAlgorithmInstance)
+    {
+        // Arrange
+        const int len = 8 * 1024;
+        const int windowSize = len - 1;
+        var bytes = new byte[len];
+        new Random().NextBytes(bytes);
+
+        // Act
+        var rotatedChecksum = rollingChecksumAlgorithmInstance.Rotate(
+            rollingChecksumAlgorithmInstance.Calculate(bytes, 0, windowSize), 
+            bytes[0], 
+            bytes[^1], 
+            windowSize);
+        var checksum = rollingChecksumAlgorithmInstance.Calculate(bytes, 1, windowSize);
+
+        // Assert
+        Assert.That(rotatedChecksum, Is.EqualTo(checksum));
+    }
+
+    public static IEnumerable<TestCaseData> SignDeltaAndApplyPatchTestCases()
+    {
+        return
+            from size in Sizes
+            from modPercentage in ModificationPercentages
+            from algo in RollingChecksumAlgorithms
+            select new TestCaseData(size, modPercentage, algo);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(SignDeltaAndApplyPatchTestCases))]
+    public async Task SignDeltaAndApplyPatchWithEveryRollingChecksumAlgorithm(int size, int modificationPercentage, IRollingChecksum algorithm)
+    {
+        //Arrange
+        var bytesToPatchFrom = GetRandomBytes(size);
+        var targetBytes = ModifyBytes(bytesToPatchFrom, modificationPercentage);
+        //Act
+        var progressReporter = Substitute.For<IProgress<ProgressReport>>();
+        //generate signature of target bytes
+        var signatureStream = new MemoryStream();
+        var signatureBuilder = new Signature.SignatureBuilder(SupportedAlgorithms.Hashing.XxHash(), algorithm);
+        await signatureBuilder.BuildAsync(new MemoryStream(bytesToPatchFrom), new Signature.SignatureWriter(signatureStream));
+        signatureStream.Seek(0, SeekOrigin.Begin);
+
+        //generate delta of base bytes and target bytes
+        var deltaStream = new MemoryStream();
+        var deltaBuilder = new DeltaBuilder();
+        await deltaBuilder.BuildDeltaAsync(new MemoryStream(targetBytes), new Signature.SignatureReader(signatureStream, progressReporter), new BinaryDeltaWriter(deltaStream));
+        deltaStream.Seek(0, SeekOrigin.Begin);
+
+        //apply delta to base bytes 
+        var patchedDataStream = new MemoryStream();
+        var deltaApplier = new DeltaApplier();
+        await deltaApplier.ApplyAsync(new MemoryStream(bytesToPatchFrom), new BinaryDeltaReader(deltaStream, progressReporter), patchedDataStream);
+        patchedDataStream.Seek(0, SeekOrigin.Begin);
+
+        //Assert
+        CollectionAssert.AreEqual(targetBytes, patchedDataStream.ToArray());
+        //make sure that the delta is reasonably small, allowing for some overhead but ensuring that the rolling checksum is effective
+        Assert.That(deltaStream.Length, Is.LessThanOrEqualTo(2.5 * modificationPercentage / 100.0 * bytesToPatchFrom.Length));
+    }
+
+    private static byte[] ModifyBytes(ReadOnlySpan<byte> input, int percentage)
+    {
+        Assert.That(percentage, Is.InRange(0, 100));
+        var length = input.Length;
+        var modified = new byte[length];
+        input.CopyTo(modified);
+
+        var bytesToModify = (int)(length * (percentage / 100.0));
+        if (bytesToModify == 0) return modified;
+
+        var random = new Random();
+        var maxStartPosition = length - bytesToModify;
+        var startIndex = maxStartPosition > 0 ? random.Next(maxStartPosition + 1) : 0;
+
+        // Modify bytes in a continuous range
+        for (var i = startIndex; i < startIndex + bytesToModify && i < length; i++)
+        {
+            modified[i] = (byte)(modified[i] + 1);
+        }
+
+        return modified;
+    }
+
+    private static byte[] GetRandomBytes(int size)
+    {
+        var data = new byte[size];
+        new Random().NextBytes(data);
+        return data;
+    }
+}

--- a/source/FastRsync.Tests/Adler32RollingChecksumTests.cs
+++ b/source/FastRsync.Tests/Adler32RollingChecksumTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using FastRsync.Hash;
+﻿using FastRsync.Hash;
 using NUnit.Framework;
 
 namespace FastRsync.Tests;
@@ -11,11 +10,11 @@ public class Adler32RollingChecksumTests
     public void Adler32RollingChecksum_CalculatesChecksum()
     {
         // Arrange
-        var data1 = Encoding.ASCII.GetBytes("Adler32 checksum test");
-        var data2 = Encoding.ASCII.GetBytes("Fast Rsync Fast Rsync");
-        var data3 = Encoding.ASCII.GetBytes("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-        var data4 = Encoding.ASCII.GetBytes("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis malesuada turpis non libero faucibus sodales. Mauris eget justo est. Pellentesque.");
-        var data5 = Encoding.ASCII.GetBytes("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+        var data1 = "Adler32 checksum test"u8.ToArray();
+        var data2 = "Fast Rsync Fast Rsync"u8.ToArray();
+        var data3 = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"u8.ToArray();
+        var data4 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis malesuada turpis non libero faucibus sodales. Mauris eget justo est. Pellentesque."u8.ToArray();
+        var data5 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."u8.ToArray();
 
         // Act
         var checksum1 = new Adler32RollingChecksum().Calculate(data1, 0, data1.Length);

--- a/source/FastRsync.Tests/Adler32RollingChecksumV3Tests.cs
+++ b/source/FastRsync.Tests/Adler32RollingChecksumV3Tests.cs
@@ -1,13 +1,14 @@
 ﻿using FastRsync.Hash;
 using NUnit.Framework;
+using System;
 
 namespace FastRsync.Tests;
 
 [TestFixture]
-public class Adler32RollingChecksumV2Tests
+public class Adler32RollingChecksumV3Tests
 {
     [Test]
-    public void Adler32RollingChecksumV2_CalculatesChecksum()
+    public void Adler32RollingChecksumV3_CalculatesChecksum()
     {
         // Arrange
         var data1 = "Adler32 checksum test"u8.ToArray();
@@ -17,11 +18,11 @@ public class Adler32RollingChecksumV2Tests
         var data5 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."u8.ToArray();
 
         // Act
-        var checksum1 = new Adler32RollingChecksumV2().Calculate(data1, 0, data1.Length);
-        var checksum2 = new Adler32RollingChecksumV2().Calculate(data2, 0, data2.Length);
-        var checksum3 = new Adler32RollingChecksumV2().Calculate(data3, 0, data3.Length);
-        var checksum4 = new Adler32RollingChecksumV2().Calculate(data4, 0, data4.Length);
-        var checksum5 = new Adler32RollingChecksumV2().Calculate(data5, 0, data5.Length);
+        var checksum1 = new Adler32RollingChecksumV3().Calculate(data1, 0, data1.Length);
+        var checksum2 = new Adler32RollingChecksumV3().Calculate(data2, 0, data2.Length);
+        var checksum3 = new Adler32RollingChecksumV3().Calculate(data3, 0, data3.Length);
+        var checksum4 = new Adler32RollingChecksumV3().Calculate(data4, 0, data4.Length);
+        var checksum5 = new Adler32RollingChecksumV3().Calculate(data5, 0, data5.Length);
 
         // Assert
         Assert.That(checksum1, Is.EqualTo(0x4ff907a1));
@@ -29,5 +30,24 @@ public class Adler32RollingChecksumV2Tests
         Assert.That(checksum3, Is.EqualTo(0x040f0fc1));
         Assert.That(checksum4, Is.EqualTo(0x2d10357d));
         Assert.That(checksum5, Is.EqualTo(0xa05ca509));
+    }
+
+
+    [Test]
+    public void Adler32RollingChecksumV3_RotatesChecksum()
+    {
+        //Arrange
+        const int len = 8 * 1024;
+        const int windowSize = len - 1;
+        var bytes = new byte[len];
+        new Random().NextBytes(bytes);
+        var adler = new Adler32RollingChecksumV3();
+
+        // Act
+        var rotatedChecksum = adler.Rotate(adler.Calculate(bytes, 0, windowSize), bytes[0], bytes[^1], windowSize);
+        var checksum = adler.Calculate(bytes, 1, windowSize);
+
+        // Assert
+        Assert.That(rotatedChecksum, Is.EqualTo(checksum));
     }
 }

--- a/source/FastRsync.Tests/PatchingBigFilesTests.cs
+++ b/source/FastRsync.Tests/PatchingBigFilesTests.cs
@@ -69,7 +69,7 @@ public class PatchingBigFilesTests
             Assert.That(CompareFilesByHash(newFileName, patchedFileName), Is.True);
             progressReporter.Received().Report(Arg.Any<ProgressReport>());
         }
-        catch (Exception e)
+        catch (Exception)
         {
             Assert.Fail();
         }

--- a/source/FastRsync/Core/SupportedAlgorithms.cs
+++ b/source/FastRsync/Core/SupportedAlgorithms.cs
@@ -55,7 +55,10 @@ namespace FastRsync.Core
         public static class Checksum
         {
             public static IRollingChecksum Adler32Rolling() { return new Adler32RollingChecksum();  }
+            [Obsolete("Adler32V2 has buggy mod operation implemented. See https://github.com/GrzegorzBlok/FastRsyncNet/issues/20")]
             public static IRollingChecksum Adler32RollingV2() { return new Adler32RollingChecksumV2(); }
+
+            public static IRollingChecksum Adler32RollingV3() { return new Adler32RollingChecksumV3(); }
 
             public static IRollingChecksum Default()
             {
@@ -64,11 +67,17 @@ namespace FastRsync.Core
 
             public static IRollingChecksum Create(string algorithm)
             {
-                if (algorithm == "Adler32")
-                    return Adler32Rolling();
-                if (algorithm == "Adler32V2")
-                    return Adler32RollingV2();
-                throw new NotSupportedException($"The rolling checksum algorithm '{algorithm}' is not supported");
+                switch (algorithm)
+                {
+                    case "Adler32":
+                        return Adler32Rolling();
+                    case "Adler32V2":
+                        return Adler32RollingV2();
+                    case "Adler32V3":
+                        return Adler32RollingV3();
+                    default:
+                        throw new NotSupportedException($"The rolling checksum algorithm '{algorithm}' is not supported");
+                }
             }
         }
     }

--- a/source/FastRsync/Hash/Adler32RollingChecksumV2.cs
+++ b/source/FastRsync/Hash/Adler32RollingChecksumV2.cs
@@ -1,5 +1,8 @@
-﻿namespace FastRsync.Hash
+﻿using System;
+
+namespace FastRsync.Hash
 {
+    [Obsolete("Adler32V2 has buggy mod operation implemented. See https://github.com/GrzegorzBlok/FastRsyncNet/issues/20")]
     public class Adler32RollingChecksumV2 : IRollingChecksum
     {
         public string Name => "Adler32V2";

--- a/source/FastRsync/Hash/Adler32RollingChecksumV3.cs
+++ b/source/FastRsync/Hash/Adler32RollingChecksumV3.cs
@@ -1,0 +1,40 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace FastRsync.Hash
+{
+    public class Adler32RollingChecksumV3 : IRollingChecksum
+    {
+        public string Name => "Adler32V3";
+
+        private const ushort Modulus = 65521;
+
+        public uint Calculate(byte[] block, int offset, int count)
+        {
+            var a = 1;
+            var b = 0;
+
+            for (count += offset; offset < count; ++offset)
+            {
+                a += block[offset];
+                a -= a >= Modulus ? Modulus : 0;
+                b += a;
+                b -= b >= Modulus ? Modulus : 0;
+            }
+            return (uint)((b << 16) | a);
+        }
+
+        public uint Rotate(uint checksum, byte remove, byte add, int chunkSize)
+        {
+            var b = (ushort)(checksum >> 16);
+            var a = (ushort)checksum;
+
+            var temp = a - remove + add;
+            a = (ushort)(temp < 0 ? temp + Modulus : temp >= Modulus ? temp - Modulus : temp);
+            temp = (b - (chunkSize * remove) + a - 1) % Modulus;
+            b = (ushort)(temp < 0 ? temp + Modulus : temp);
+
+            return (uint)((b << 16) | a);
+        }
+    }
+}


### PR DESCRIPTION
Mark Adler32V2 as obsolete due to modulo bug (https://github.com/GrzegorzBlok/FastRsyncNet/issues/20). 
Add comprehensive algorithm test suite for correctness and patching.